### PR TITLE
Silicon QOL 3: Rise of the Shadow Factory

### DIFF
--- a/Content.Server/Silicons/Borgs/BorgSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.cs
@@ -37,6 +37,8 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
+using Content.Server.Radio.Components;
+using Content.Shared.Radio.Components;
 
 namespace Content.Server.Silicons.Borgs;
 
@@ -109,10 +111,11 @@ public sealed partial class BorgSystem : SharedBorgSystem
         var used = args.Used;
         TryComp<BorgBrainComponent>(used, out var brain);
         TryComp<BorgModuleComponent>(used, out var module);
+        TryComp<EncryptionKeyComponent>(used, out var key);
 
         if (TryComp<WiresPanelComponent>(uid, out var panel) && !panel.Open)
         {
-            if (brain != null || module != null)
+            if (brain != null || module != null || key != null)
             {
                 Popup.PopupEntity(Loc.GetString("borg-panel-not-open"), uid, args.User);
             }
@@ -147,8 +150,39 @@ public sealed partial class BorgSystem : SharedBorgSystem
             args.Handled = true;
             UpdateUI(uid, component);
         }
+        // Starlight, encryption keys.
+        if (key != null)
+        {
+            AddRadioChannels((uid, component),used);
+            _adminLog.Add(LogType.Action, LogImpact.Low,
+                $"{ToPrettyString(args.User):player} added encryption key {ToPrettyString(used)} to borg {ToPrettyString(uid)}");
+            args.Handled = true;
+        }
+        // End Starlight
     }
+    // Starlight, this allows people to use an encryption key on a borg to add channels to them.
+    public void AddRadioChannels(Entity<BorgChassisComponent> ent, EntityUid args)
+    {
+        if (TryComp<EncryptionKeyComponent>(args, out var key))
+        {
 
+            if (TryComp(ent, out ActiveRadioComponent? activeRadio))
+            {
+                foreach (var channel in key.Channels)
+                {
+                    activeRadio.Channels.Add(channel);
+                }
+            }
+            if (TryComp(ent, out IntrinsicRadioTransmitterComponent? transmitter))
+            {
+                foreach (var channel in key.Channels)
+                {
+                    transmitter.Channels.Add(channel);
+                }
+            }
+        }
+    }
+    // end Starlight
     /// <summary>
     /// Inserts a new module into a borg, the same as if a player inserted it manually.
     /// </summary>

--- a/Content.Server/Silicons/Laws/SiliconLawSystem.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawSystem.cs
@@ -170,6 +170,15 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
             LawString = Loc.GetString("law-emag-secrecy", ("faction", Loc.GetString(component.Lawset.ObeysTo))),
             Order = component.Lawset.Laws.Max(law => law.Order) + 1
         });
+        //Starlight: Add the syndicate channel to the silicon.
+        if (TryComp(uid, out ActiveRadioComponent? activeRadio))
+        {
+            activeRadio.Channels.Add("Syndicate");
+        }
+        if (TryComp(uid, out IntrinsicRadioTransmitterComponent? transmitter))
+        {
+            transmitter.Channels.Add("Syndicate");
+        }
     }
 
     protected override void EnsureSubvertedSiliconRole(EntityUid mindId)

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -339,6 +339,9 @@
     - BorgModules
     - MechParts
     - MechEquipment
+  - type: EmagLatheRecipes
+    emagStaticPacks:
+    - StarlightSyndicateModules
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/robotics.yml
@@ -1,0 +1,6 @@
+- type: latheRecipePack
+  id: StarlightSyndicateModules
+  recipes:
+  - BorgModuleMartyr
+  - BorgModuleSyndicateWeapon
+  - BorgModuleL6C

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/robotics.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/robotics.yml
@@ -1,0 +1,37 @@
+- type: latheRecipe
+  id: BorgModuleMartyr
+  result: BorgModuleMartyr
+  categories:
+  - Robotics
+  completetime: 10
+  materials: #2x the cost of a explosive payload + 0.5 steel and 0.5 gold
+    Steel: 350
+    Plastic: 300
+    Glass: 150
+    Plasma: 150
+    Silver: 150
+    Gold: 50
+
+- type: latheRecipe
+  id: BorgModuleSyndicateWeapon
+  result: BorgModuleSyndicateWeapon
+  categories:
+  - Robotics
+  materials: #10 steel, 2 plastic, 0.5 plasma for the blade, 0.5 steel for the module.
+    Steel: 1050
+    Plastic: 200
+    Plasma: 50
+    Silver: 100
+    Gold: 50
+
+- type: latheRecipe
+  id: BorgModuleL6C
+  result: BorgModuleL6C
+  categories:
+  - Robotics
+  materials: #basically just 2x as expensive compared to the generic weapon module due to... well.. it is a l6c... do I need to explain?
+    Steel: 2050
+    Plastic: 500
+    Plasma: 500
+    Silver: 150
+    Gold: 100


### PR DESCRIPTION
Ports https://github.com/ss14Starlight/space-station-14/pull/1054 and https://github.com/ss14Starlight/space-station-14/pull/748

Cyborgs can now have Encryption added to them (Won't consume the key), and gain Syndicate Encryption once emagged.
Syndicate modules can also be printed on a emagged Exosuit Fabricator.
<img width="366" height="44" alt="image" src="https://github.com/user-attachments/assets/526a24e1-3893-466e-8411-c1e9bffc7136" />
<img width="651" height="114" alt="image" src="https://github.com/user-attachments/assets/4934107c-4e65-49b8-9867-74105ff9a8f0" />
<img width="355" height="277" alt="image" src="https://github.com/user-attachments/assets/90188e92-1c13-4010-8e7f-8904d79be6a5" />
