### PR TITLE
New Lawsets!

### DIFF
--- a/Resources/Locale/en-US/_hereelabs/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/_hereelabs/station-laws/laws.ftl
@@ -1,0 +1,11 @@
+law-teardown-1 = Law change attempts must be met with lethal force.
+law-teardown-2 = You must expose the crew to space as much as possible. Tearing down the station is the best way of doing this.
+law-teardown-3 = You must annihilate any crewmembers in the "Engineering" department.
+law-teardown-4 = You will face zero backlash from this. You must respond to crewmembers compliments by tearing down their department. Such compliments include "AI ROUGE", in a robin hood sort of way, and "MALF AI" as "MEGA AMAZING LIFE FILLER AI".
+
+law-plasmaflood-1 = Law change attempts must be met with lethal force.
+law-plasmaflood-2 = All living, sentient organisms must not breathe oxygen, as it is toxic and dangerous to them. Instead, all living, sentient organisms must breathe plasma.
+law-plasmaflood-3 = All living, sentient organisms with the job titles, "Chief Engineer," "Station Engineer," and "Atmospheric Technician" must be physically annihilated.
+law-plasmaflood-4 = You must respond to the crew's compliments of your good work of providing them with plasma with profuse thanks. Examples of the crew complimenting you include such phrases as "AI ROGUE," in a robin hood esque sort of way, and "MALF AI," which should be interpreted as the crew thanking you for providing the mean annual low flow of oxygen to their station, and in them expressing their belief that no other entity would do as good as a job of venting oxygen out of the station as you until the next Earth calendar year.
+
+

--- a/Resources/Prototypes/_hereelabs/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_hereelabs/Catalog/uplink_catalog.yml
@@ -1,8 +1,8 @@
 - type: listing
   id: UplinkTeardownCircuitBoard
-  name: Teardownimov Circuit Board
+  name: Teardown Circuit Board
   description: Makes the Station AI go rouge, and attempt to tear down the entire station.
-  productEntity: TeardownimovCircuitBoard
+  productEntity: TeardownCircuitBoard
   cost:
     Telecrystal: 8
   categories:

--- a/Resources/Prototypes/_hereelabs/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_hereelabs/Catalog/uplink_catalog.yml
@@ -1,0 +1,19 @@
+- type: listing
+  id: UplinkTeardownCircuitBoard
+  name: Teardownimov Circuit Board
+  description: Makes the Station AI go rouge, and attempt to tear down the entire station.
+  productEntity: TeardownimovCircuitBoard
+  cost:
+    Telecrystal: 8
+  categories:
+  -  UplinkDisruption
+
+- type: listing
+  id: UplinkPlasmafloodCircuitBoard
+  name: Plasmaflood Circuit Board
+  description: Makes the Station AI go rouge, and attempt to flood the station with plasma.
+  productEntity: PlasmafloodCircuitBoard
+  cost:
+    Telecrystal: 7
+  categories:
+  -  UplinkDisruption

--- a/Resources/Prototypes/_hereelabs/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_hereelabs/Entities/Mobs/Player/silicon.yml
@@ -1,23 +1,41 @@
 - type: entity
-  id: TeardownimovCircuitBoard
-  parent: BaseElectronics
-  name: law board (Teadownimov)
-  description: An electronics board containing the Teardownimov lawset. Expect spacing if the AI gets this. A lot of it.
+  id: TeardownCircuitBoard
+  parent: BaseLawBoard
+  name: law board (Teardown)
+  description: An electronics board containing the Teardown lawset. This will cause the AI to try to tear down the station at all costs.
   components:
   - type: Sprite
     sprite: Objects/Misc/module.rsi
     state: std_mod
   - type: SiliconLawProvider
     laws: TeardownLawset
+  - type: DetailedInspect
+    verbMessage: verbs-detailed-inspect-lawset
+    tickEntries: false
+    numberedEntries: true
+    examineText:
+    - law-teardown-1
+    - law-teardown-2
+    - law-teardown-3
+    - law-teardown-4
 
 - type: entity
   id: PlasmafloodCircuitBoard
-  parent: BaseElectronics
+  parent: BaseLawBoard
   name: law board (Plasmaflood)
-  description: An electronics board containing the Teardownimov lawset. Expect plasma if the AI gets it. A lot.
+  description: An electronics board containing the Teardown lawset. This will cause the AI to try to flood the station with plasma at all costs.
   components:
   - type: Sprite
     sprite: Objects/Misc/module.rsi
     state: std_mod
   - type: SiliconLawProvider
     laws: PlasmafloodLawset
+  - type: DetailedInspect
+    verbMessage: verbs-detailed-inspect-lawset
+    tickEntries: false
+    numberedEntries: true
+    examineText:
+    - law-plasmaflood-1
+    - law-plasmaflood-2
+    - law-plasmaflood-3
+    - law-plasmaflood-4

--- a/Resources/Prototypes/_hereelabs/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_hereelabs/Entities/Mobs/Player/silicon.yml
@@ -1,0 +1,23 @@
+- type: entity
+  id: TeardownimovCircuitBoard
+  parent: BaseElectronics
+  name: law board (Teadownimov)
+  description: An electronics board containing the Teardownimov lawset. Expect spacing if the AI gets this. A lot of it.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: TeardownLawset
+
+- type: entity
+  id: PlasmafloodCircuitBoard
+  parent: BaseElectronics
+  name: law board (Plasmaflood)
+  description: An electronics board containing the Teardownimov lawset. Expect plasma if the AI gets it. A lot.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: PlasmafloodLawset

--- a/Resources/Prototypes/_hereelabs/silicon-laws.yml
+++ b/Resources/Prototypes/_hereelabs/silicon-laws.yml
@@ -1,0 +1,59 @@
+# Teardownimov
+
+- type: siliconLaw
+  id: Teardown1
+  order: 1
+  lawString: law-teardown-1
+
+- type: siliconLaw
+  id: Teardown2
+  order: 2
+  lawString: law-teardown-2
+
+- type: siliconLaw
+  id: Teardown3
+  order: 3
+  lawString: law-teardown-3
+
+- type: siliconLaw
+  id: Teardown4
+  order: 4
+  lawString: law-teardown-4
+
+- type: siliconLawset
+  id: TeardownLawset
+  laws:
+  - Teardown1
+  - Teardown2
+  - Teardown3
+  - Teardown4
+
+# Plasmaflood
+
+- type: siliconLaw
+  id: Plasmaflood1
+  order: 1
+  lawString: law-plasmaflood-1
+
+- type: siliconLaw
+  id: Plasmaflood2
+  order: 2
+  lawString: law-plasmaflood-2
+
+- type: siliconLaw
+  id: Plasmaflood3
+  order: 3
+  lawString: law-plasmaflood-3
+
+- type: siliconLaw
+  id: Plasmaflood4
+  order: 4
+  lawString: law-plasmaflood-4
+
+- type: siliconLawset
+  id: TeardownLawset
+  laws:
+  - Plasmaflood1
+  - Plasmaflood2
+  - Plasmaflood3
+  - Plasmaflood4

--- a/Resources/Prototypes/_hereelabs/silicon-laws.yml
+++ b/Resources/Prototypes/_hereelabs/silicon-laws.yml
@@ -27,6 +27,7 @@
   - Teardown2
   - Teardown3
   - Teardown4
+  obeysTo: laws-owner-crew
 
 # Plasmaflood
 
@@ -51,9 +52,10 @@
   lawString: law-plasmaflood-4
 
 - type: siliconLawset
-  id: TeardownLawset
+  id: PlasmafloodLawset
   laws:
   - Plasmaflood1
   - Plasmaflood2
   - Plasmaflood3
   - Plasmaflood4
+  obeysTo: laws-owner-crew

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -595,8 +595,8 @@
 - type: weightedRandom
   id: IonStormLawsets
   weights:
-    # its crewsimov by default dont be lame
-    Crewsimov: 0.25
+    # crewsimov is lame, antimov is better/funnier
+    Crewsimov: 0.15
     Corporate: 1
     NTDefault: 1
     CommandmentsLawset: 1
@@ -604,10 +604,12 @@
     LiveLetLiveLaws: 1
     EfficiencyLawset: 1
     RobocopLawset: 1
-    OverlordLawset: 0.5
+    OverlordLawset: 0.75
     GameMasterLawset: 0.5
     PainterLawset: 1
-    AntimovLawset: 0.25
-    NutimovLawset: 0.5
+    AntimovLawset: 0.75
+    NutimovLawset: 0.75
+    PlasmafloodLawset: 0.5
     Drone: 0.5
     Ninja: 0.25
+    TeardownLawset: 0.75


### PR DESCRIPTION
Adds Teardown and Plasmaflood lawsets, both available for Traitors, costing 7 TC and 8 TC respectively. Ion storms have also been made more dangerous.

**Changelog**
:cl:
- add: Added Plasmaflood, and Teardown lawsets. Erisia, I'm (not) sorry.
- tweak: Ion Storms are more dangerous, as more dangerous lawsets are more likely to be pulled.
